### PR TITLE
Update rsyslog-server.md

### DIFF
--- a/docs/products/cloud/aws-marketplace/rsyslog-server.md
+++ b/docs/products/cloud/aws-marketplace/rsyslog-server.md
@@ -9,54 +9,54 @@ summary: Rsyslog Server for developers for ease debugging.
 
 Collecting logs is useful for many purposes, but over time it can become very expensive to use solutions from Cloud providers. Such solutions may seem easy and convenient at first, but when you start sending thousands of entries a day, your Cloud bill will dramatically inflate.
 
-Of course, the features of a managed Cloud solution outweigh the price in some cases, but in others, you just want to see what the OS or your app is doing for easy debugging.
+Of course, the benefits of a managed Cloud solution often outweigh the price in some cases, but sometimes you just want to quickly and easily see what the OS or your app is doing for easy debugging.
 
 Our Rsyslog server can help you centralize all your log collections in one place for a fixed price, regardless of how many logs you send. Our server is set up in such a way that the logs have a 30-day retention period and are organized in folders using the host name of the client server. Logs are all stored in the default folder path `/var/log/0x4447-rsyslog` for easy access.
 
-Not to mention security. Our setup creates a SSL certificate automatically, and stores it in S3 to make sure that you can send data in an encrypted way, while also allowing the system to pull the generated cert from S3. This way the cert stays the same across the operation allowing your clients to keep sending logs securely to the server.
+Not to mention security, the connection is encrypted by default. Our setup automatically creates a SSL certificate and stores it in S3 to make sure that you can send data in an encrypted way, while also allowing the system to pull the generated cert from S3. This way the cert stays the same across the operation, allowing your clients to keep sending logs securely to the server.
 
-Bring down your costs now.
+Use our Rsyslog server to bring down your costs now.
 
 # 📍 Our Differentiating Factor
 
-We also want to let you know that this is not a regular product; what we build for the marketplace is what we use ourselves on a day-to-day basis. One of our signature traits is that we hate repetitive tasks that can easily be automated. If we find something repetitive in our day-to-day use of our products, rest assured that we'll automate the repetition.
+We also want to let you know that this is not a regular product. What we build for the marketplace is what we use ourselves on a day-to-day basis. One of our signature traits is that we hate repetitive tasks that can easily be automated. So, if we find something repetitive in our day-to-day use of our products, rest assured that we'll automate the repetition.
 
-Our goal is to give you a good foundation for your company.
+Our goal is to provide you with the right foundation for your company.
 
 # 📜 Understand the basics
 
 ### Security
 
-Our product is configured to allow any server to send logs to it. The data will be sent over an ecrypted connection, but there is not credential system to prevent instances to send data. For this reason, this product should not be acessible from the public internet. It was designed to be deployed in a private subnet within a VPC, to allow only local servers to send logs to it. 
+Our product is configured to allow any server to send it logs. The data will be sent over an ecrypted connection, but there is not a credential system to prevent instances from sending data. For this reason, this product should not be acessible from the public Internet. It was designed to be deployed in a private subnet within a VPC, to allow only local servers to send it logs. 
 
 You can block traffic and instances using ACL rules at the VPC or instance level.
 
 ### Resilience
 
-Our Rsyslog server has built in resilience to make sure that even if the server gets terminated, it has all the capability for the same configuration to be applied to a new instance. Meaning, if you provide a S3 bucket in the EC2 UserData, we will store all the necessary data in this bucket to allow you to automate the whole client setup in the most automated way possible. This way the clients can keep sending longs as soon as the server shows up.
+Our Rsyslog server has built in resilience to make sure that even if the server gets terminated, it has the capability to apply the same configuration to each new instance. Meaning, if you provide a S3 bucket in the EC2 UserData, we will store all the necessary data in this bucket to allow you to automate the whole client setup in the most efficient, automated way possible. This way your clients can keep sending logs as soon as the server shows up.
 
-A very important fact, the certificate relies in the internal IP of the server. This means that for the cert to work even after termination, the instance needs to start with the same internal (local) IP that was used to create the initial cert.
+Another important component is that the certificate relies on the internal IP of the server. This means that for the cert to work even after termination, the instance needs to start with the same internal (local) IP that was used to create the initial cert.
 
 # 🗂 CloudFormation
 
 <a target="_blank" href="https://console.aws.amazon.com/cloudformation/home#/stacks/new?stackName=zer0x4447-rsyslog&templateURL=https://s3.amazonaws.com/0x4447-drive-cloudformation/rsyslog-server.json">
 <img align="left" style="float: left; margin: 0 10px 0 0;" src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png"></a>
 
-We provide a complementary CloudFormation file. Click the orange button to deploy the stack. If you want to check the CloudFormation yourself, follow this [link](https://github.com/0x4447-Paid-Products/0x4447_product_paid_rsyslog).
+We provide a complementary CloudFormation file. Click the orange button to deploy the stack. If you want to check the CloudFormation yourself, follow [this link](https://github.com/0x4447-Paid-Products/0x4447_product_paid_rsyslog).
 
-Using our CF will allow you to deploy the stack with minimal work on your part. But if you'd like to do the deployment by hand, from this point on you'll find the manual how to do so.
+Using our CF will allow you to deploy the stack with minimal work on your part. But, if you'd like to deploy the stack by hand, from this point on you'll find the manual on how to do so.
 
 ---
 
 # 📚  Manual
 
-Before launching an instance you'll have to do some manual work to make everything work correctly. Please follow this steps in order displayed here.
+Before launching an instance, you'll have to do some manual inputs to make everything work correctly. Please follow these steps in the order displayed here:
 
 **WARNING**: text written in capital letters needs to be replaced with real values.
 
 ### Custom Role
 
-You need to create a EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script, for it - to reuse the same cert on termination, and for your clients to automatically pull the cert when they boot up. This is the Poliyc Document you need add create.
+You need to create an EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script, for it - to reuse the same cert on termination, and for your clients to automatically pull the cert when they boot up. This is the Policy Document you need add create.
 
 ```json
 {
@@ -88,14 +88,14 @@ You need to create a EC2 role to allow the Rsyslog Server to upload and get the 
 
 ### Security Group
 
-A default security group will be created for you automatically from the product configuration, but if you'd like to make one by hand, you need to have this ports open towards the instance:
+A default security group will automatically be created for you from the product configuration, but if you'd like to make one by hand, you'll need to have these ports open towards the instance:
 
 - `22` over `TCP` for remote managment.
 - `6514` over `TCP` for Rsyslog to take logs in.
 
 ### Bash Script for UserData
 
-When you start your instance to automate the whole process you should provide a bucket name so we can copy over to S3 the auto generate certificate which must be used by the clients to send encrypted data to the server.
+When you start to automate your instance, the whole process will provide you with a bucket name so that we can copy the auto generate certificate over to S3, which must be used by the client to send encrypted data to the server.
 
 ```bash
 #!/bin/bash
@@ -107,22 +107,22 @@ echo S3_BUCKET=$S3_BUCKET >> /home/ec2-user/.env
 Explanation:
 
 1. Set the name of the S3 bucket.
-1. Append the S3 bucket anem to the .env file
+1. Append the S3 bucket anem to the .env file.
 
 **Understand how UserData works**
 
-It is important to note that the content of the UserData field will be only executed once, when the Instacne starts for the first time. Meaning it won't be trigered if you stop and start the instacne. If you chose to not enable resiliance, and skip the UserData script at boot time, you won't be able to later on update the UserData with the script and expect for the autoamtion to take place. You have to options: 
+It is important to note that the content of the UserData field will be only executed once, which occurs when the instance starts for the first time. This means that the content of the UserData won't be trigered if you stop and start the instance. If you choose to not enable resilience and want to skip the UserData script at boot time, then you won't be able to later update the UserData with the script and can't expect for the automation to take place. You have two options: 
 
 - Either you follow [this link](https://aws.amazon.com/premiumsupport/knowledge-center/execute-user-data-ec2/) for a work around.
-- Or your start a new Instacne, this time with the right UserData, and then copy over from the old isntance to the new one all the configuration files.
+- Or your start a new instance, this time with the right UserData, and then copy over all the configuration files from the old instance to the new one.
 
 ### Connect to the server
 
-Once the instance is up and running, get it's IP and connect to the instance over SSH uisng the slected key at deployment time.
+Once the instance is up and running, get its IP and connect to the instance over SSH uisng the slected key at deployment time.
 
 # 🖥 Clients Setup
 
-Once the server is deployed correctly, you can configure your clients with the following `UserData` to setup everything automatically. This way at boot time everything will be setup automatically for you.
+Once the server is deployed correctly, you can configure your clients with the following `UserData` to setup everything automatically. This ensures that everything will be automatically set up at boot time.
 
 ```bash
 #!/bin/bash
@@ -149,7 +149,7 @@ chmod +x /home/ec2-user/client-setup.sh
 
 # 👷‍♂️ User Management
 
-By default we create a custom user group in the system called `rsyslog`. This makes it easier for you to add developers as individual users to access the logs. This way they can freely look at the logs without having access to the whole system.
+By default we create a custom user group in the system called `rsyslog`. This makes it easier for you to add developers as individual users to access the logs. Developers can then freely look at the logs without having access to the whole system.
 
 ### How to create a user
 
@@ -189,7 +189,7 @@ You can also setup a client manually if you can't use the EC2 UserData.
 
 	`scp -i /path/to/key ca-cert.pem ec2-user@INSTANCE_IP:/tmp`
 
-3. Move the cert I the final location using `sudo` since SCP dose not support running commands using `sudo`.
+3. Move the cert to the final location using `sudo` since SCP dose not support running commands using `sudo`.
 
 	`ssh -i /path/to/key ec2-user@INSTANCE_IP sudo mv /tmp/ca-cert.pem /etc/ssl`
 
@@ -203,29 +203,29 @@ You can also setup a client manually if you can't use the EC2 UserData.
 
 	`scp -i /path/to/key client-setup.sh ec2-user@INSTANCE_IP:/tmp`
 
-3. Once the file gets uploaded, we need to make it executable.
+3. Once the file gets uploaded, make sure it's executable.
 
 	`ssh -i /path/to/key ec2-user@INSTANCE_IP chmod +x /tmp/client-setup.sh`
 
-4. As the last step we have to log in to your client server and run the script.
+4. For the last step, log in to your client server and run the script.
 
 	`/tmp/client-setup.sh IP_OR_DNS_TO_THE_RSYSLOGSERVER`
 
 # ❓ Where are my logs?
 
-The logs can be found in the `/var/log/0x4447-rsyslog` folder. There, you'll find folders for each client sending logs. The client host name will be used for the folder names.
+The logs can be found in the `/var/log/0x4447-rsyslog` folder. There you'll find folders for each client's sending logs. The client host name will be used for the folder names.
 
 # 🚨 Test The Setup
 
-Be sure to test the server to make sure it behaves the way we advertise it, not becasue we don't belive it works correctly, but to make sure you are confortable with the product and knows how it works. Especially the resiliance mode.
+Be sure to test the server to make sure it behaves the way we advertise it; not becasue we don't belive it works correctly, but to make sure that you are confortable with the product and knows how it works, especially the resiliance mode.
 
-Termiante the instace and start a new one with the correct UserData, and see if after the instacne booted everything works as expected.
+Terminate the instance and start a new one with the correct UserData in order to see if everything works as expected after the instance booted.
 
 # 🔔 Security Concerns
 
-Bellow we give you a list of potentail ideas worth considiering regarding security, but this list dose not exausts all posobilities. It is just a good starting point.
+Bellow we give you a list of potentail ideas to consider regarding security, but this list is not exhaustive – it is just a good starting point.
 
-- Never expose this server to the public. Use it only inside a private network to limit who can send logs to it.
+- Never expose this server to the public. Use it only inside a private network to limit who can send it logs.
 - Allow logging only from specific subnets.
 - Block public SSH access.
 - Allow SSH connection only from limited subnets.
@@ -234,4 +234,4 @@ Bellow we give you a list of potentail ideas worth considiering regarding securi
 
 # 🎗 Support 
 
-If you have any questions regarding our product, go to our [support page](https://support.0x4447.com/).
+If you have any questions regarding our products, go to our [support page](https://support.0x4447.com/).

--- a/docs/products/cloud/aws-marketplace/rsyslog-server.md
+++ b/docs/products/cloud/aws-marketplace/rsyslog-server.md
@@ -56,7 +56,7 @@ Before launching an instance, you'll have to do some manual inputs to make every
 
 ### Custom Role
 
-You need to create an EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script, for it - to reuse the same cert on termination, and for your clients to automatically pull the cert when they boot up. This is the Policy Document you need add create.
+You need to create an EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script from S3. This allows you to reuse the same cert on termination, and allows for your clients to automatically pull the public cert when they boot up. Below is the Policy Document that you need add to create this:
 
 ```json
 {


### PR DESCRIPTION
This should be good to go besides the one section that I don't understand the technical language but know that it needs some tweaking:
"You need to create a EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script, for it - to reuse the same cert on termination, and for your clients to automatically pull the cert when they boot up. This is the Policy Document you need add create."
If I understand correctly, I think it could be changed to something like:
"You need to create an EC2 role to allow the Rsyslog Server to upload and get the certificate and bash script for it. This allows you to reuse the same cert on termination, and allows for your clients to automatically pull the cert when they boot up. Below is the Policy Document that you need add to create this:"

