### PR TITLE
bug: #74 homepage link latest product version

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -91,12 +91,12 @@ module.exports = {
             image: '/images/products/sftp.png',
             items: [
               {
-                text: '1.0.1',
-                link: '/sftp/1.0.1/'
-              },
-              {
                 text: '1.0.2',
                 link: '/sftp/1.0.2/'
+              },
+              {
+                text: '1.0.1',
+                link: '/sftp/1.0.1/'
               }
             ]
           },


### PR DESCRIPTION
- Reorder SFTP versions in the menu config to have latest version first

Note, as previously discussed, the first available product version in the menu config is used on the homepage to link to the product page.

Closes #74 